### PR TITLE
bugfix: Allow category creation on recipe form

### DIFF
--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -33,7 +33,7 @@
   </div>
 
   <div class="my-5 lg:my-2 relative">
-    <%= form.collection_select :category_names, Category.all, :name, :name, {}, { data: { controller: "tom-select" }, multiple: true, placeholder: "Add Categories" } %>
+    <%= form.collection_select :category_names, Category.all, :name, :name, {}, { data: { controller: "tom-select", 'tom-select-create-value': true }, multiple: true, placeholder: "Add Categories" } %>
   </div>
 
   <div class="my-10 relative">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When extracting the filter functionality from style changes, I forgot to set the value to allow creation for categories on the recipe form

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->
Verified on dev machine new categories can now be added when editing a recipe.