### PR TITLE
Don't report unhealthy if tag url is down

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,10 @@ class ApplicationController < ActionController::Base
     uri = URI(tag_url)
     res = get_tag(uri)
 
-    return unless res.is_a?(Net::HTTPSuccess)
+    unless res.is_a?(Net::HTTPSuccess)
+      Rails.logger.error("Health check: failed to fetch tag from #{uri} with status #{res.code}")
+      return
+    end
 
     JSON.parse(res.body)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   include Pundit::Authorization
   after_action :verify_pundit_authorization, except: %i[health_check]
 
+  TAG_TIMEOUT = 5
+
   def health_check
     render json: { started_at:, updated_at:, ok: healthy? }, status:
   end
@@ -19,7 +21,7 @@ class ApplicationController < ActionController::Base
 
   def updated_at
     @updated_at ||=
-      Rails.cache.fetch(cache_key, skip_nil: true, expires_in: 5.minutes) do
+      Rails.cache.fetch(cache_key, expires_in: 5.minutes) do
         tag&.dig('last_updated')
       end
   end
@@ -28,10 +30,20 @@ class ApplicationController < ActionController::Base
     return if tag_url.blank?
 
     uri = URI(tag_url)
-    res = Net::HTTP.get_response(uri)
+    res = get_tag(uri)
+
     return unless res.is_a?(Net::HTTPSuccess)
 
     JSON.parse(res.body)
+  end
+
+  def get_tag(uri)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: TAG_TIMEOUT) do |http|
+      req = Net::HTTP::Get.new(uri)
+      http.request(req)
+    end
+  rescue Net::ReadTimeout
+    Rails.logger.warn("Health check: timed out fetching tag from #{uri}")
   end
 
   def tag_url

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < ActionController::Base
   end
 
   def healthy?
-    updated_at.present? && Time.zone.parse(updated_at) < started_at
+    updated_at.blank? || Time.zone.parse(updated_at) < started_at
   end
 
   def status


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The app deployed to production was unavailable due to an outage with the Docker Hub tags operations. The health check endpoint reports unhealthy if it is running an old version of the image. But it's also reporting unhealthy when unable to get the latest tag information.  This change should just report healthy if the latest tag information is unavailable.

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->

Verified healthy in development environment briefly while Docker Hub was still having issues. Temporarily set timeout very low to verify graceful handling of error conditions.