### PR TITLE
Only set TCP logger if host is set

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,10 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  log = TCPSocket.new(ENV.fetch("LOG_HOST", "127.0.0.1"), ENV.fetch("LOG_PORT", 9000))
+  log = STDOUT
+  if ENV["LOG_HOST"].present?
+    log = TCPSocket.new(ENV["LOG_HOST"], ENV.fetch("LOG_PORT", 9000))
+  end
   config.logger = ActiveSupport::Logger.new(log)
     .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Docker image build was failing on the asset precompile step because that runs in production mode and was trying to connect to the log host which doesn't exist.

This change will default to STDOUT logging unless LOG_HOST is defined

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->