### PR TITLE
Add readiness check to health_check

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,10 +10,18 @@ class ApplicationController < ActionController::Base
   TAG_TIMEOUT = 5
 
   def health_check
-    render json: { started_at:, updated_at:, ok: healthy? }, status:
+    params[:q] == 'ready' ? ready_response : live_response
   end
 
   private
+
+  def ready_response
+    head :ok
+  end
+
+  def live_response
+    render json: { started_at:, updated_at:, ok: healthy? }, status:
+  end
 
   def started_at
     Uptime::STARTED_AT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Add a parameter to support different checks for readiness vs liveness probe.

The readiness probe controls whether traffic should be routed to a container. It allows the app to recover and resume accepting requests.

The liveness probe determines if the container should be restarted because its state is not recoverable.  We're mostly just using this to trigger deploys after the main image is updated.

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->