### PR TITLE
Use lograge for production logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,6 @@ gem "rails", "~> 7.2.0"
 gem "sprockets-rails"
 
 # Use pg as the database for Active Record
-# gem "pg", "~> 1.4"
-
 gem "pg", "~> 1.1"
 
 # Use the Puma web server [https://github.com/puma/puma]
@@ -27,7 +25,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-gem "tailwindcss-rails", "~> 4.0" 
+gem "tailwindcss-rails", "~> 4.0"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
@@ -55,6 +53,9 @@ gem "pundit", "~> 2.5"
 
 # Down image download
 gem "down", "~> 5.0"
+
+# Production logging
+gem "lograge"
 
 # Use Sass to process CSS
 # gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,11 @@ GEM
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.6.6)
+    lograge (0.14.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -259,6 +264,8 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     rexml (3.4.1)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
@@ -374,6 +381,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   jbuilder
+  lograge
   pg (~> 1.1)
   pry
   puma (< 7)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,9 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
+  config.lograge.enabled = true
+  config.lograge.ignore_actions = ['ApplicationController#health_check']
+
   # Use a different cache store in production.
   config.cache_store = :memory_store
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Lograge provides a way to filter out the health_check route from logs, which is nice because that route is used pretty extensively by kubernetes and uptime monitors.

This also helps consolidate the request logs to fewer lines.

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->