### PR TITLE
Use semantic logger for production logs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-gem "tailwindcss-rails", "~> 4.0" 
+gem "tailwindcss-rails", "~> 4.0"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
@@ -55,6 +55,10 @@ gem "pundit", "~> 2.5"
 
 # Down image download
 gem "down", "~> 5.0"
+
+# Production Logging
+gem "net_tcp_client"
+gem "rails_semantic_logger"
 
 # Use Sass to process CSS
 # gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
+    net_tcp_client (2.2.1)
     nio4r (2.7.4)
     nokogiri (1.18.5-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -244,6 +245,10 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_semantic_logger (4.19.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -318,6 +323,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    semantic_logger (4.17.0)
+      concurrent-ruby (~> 1.0)
     shoulda-matchers (6.4.0)
       activesupport (>= 5.2.0)
     smart_properties (1.17.0)
@@ -374,12 +381,14 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   jbuilder
+  net_tcp_client
   pg (~> 1.1)
   pry
   puma (< 7)
   pundit (~> 2.5)
   pundit-matchers (~> 4.0)
   rails (~> 7.2.0)
+  rails_semantic_logger
   rspec-rails (~> 7.1.0)
   rubocop
   rubocop-capybara


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Semantic logger provides a way to filter out the health_check route from logs, which is nice because that route is used pretty extensively by kubernetes and uptime monitors.

It also does a good job at replacing the standard rails logs with a structured format that works well with a log aggregator.

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->

Pushed to staging, verified STDOUT logging still works in the new format
Did some local setup to run app similar to production, verified logs sent to log server, filtering health checks