### PR TITLE
Update search results links

### DIFF
--- a/app/javascript/controllers/search_results_controller.js
+++ b/app/javascript/controllers/search_results_controller.js
@@ -2,34 +2,70 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
+    this._abort = new AbortController()
+
+    if (!this._onClickLink) this._onClickLink = this.onClickLink.bind(this)
+
     this.initializeObserver(this.element)
   }
 
-  initializeObserver(targetNode) {
-    const config = { attributes: false, childList: true, subtree: true }
-    this.searchResultsObserver = new MutationObserver(
-      this.searchResultsCallback,
-    )
-    this.searchResultsObserver.observe(targetNode, config)
+  onClickLink(e) {
+    const href = e.currentTarget.getAttribute("href")
+    if (href) {
+      e.preventDefault()
+
+      const params = new URLSearchParams({ url: href })
+      window.location.href = `web_result?${params}`
+    }
   }
 
-  searchResultsCallback(mutationList, observer) {
+  initializeObserver(targetNode) {
+    if (this._observer) return
+
+    if (!this._onMutations)
+      this._onMutations = this.searchResultsCallback.bind(this)
+
+    const config = { attributes: false, childList: true, subtree: true }
+    this._observer = new MutationObserver(this._onMutations)
+    this._observer.observe(targetNode, config)
+  }
+
+  searchResultsCallback(mutationList) {
     for (const mutation of mutationList) {
       if (mutation.type === "childList") {
         for (const node of mutation.addedNodes) {
-          if (
-            node.nodeType === Node.ELEMENT_NODE &&
-            node.matches("div.gsc-result")
-          ) {
-            const link = node.querySelector("div.gs-result a")
-            link.addEventListener("click", function (e) {
-              e.preventDefault()
+          if (!(node.nodeType === Node.ELEMENT_NODE)) continue
 
-              const params = new URLSearchParams({
-                url: this.getAttribute("href"),
-              })
-              window.location.href = `web_result?${params}`
-            })
+          if (node.matches("div.gsc-result")) {
+            const links = node.querySelectorAll("a")
+            for (const link of links) {
+              link.addEventListener("click", this._onClickLink)
+              link._boundToController = true
+            }
+          } else if (node.matches("div.gs-mobilePreview img.gs-imagePreview")) {
+            const link = node.parentElement
+            link.addEventListener("click", this._onClickLink)
+            link._boundToController = true
+          }
+        }
+
+        for (const node of mutation.removedNodes) {
+          if (!(node.nodeType === Node.ELEMENT_NODE)) continue
+
+          if (node.matches("div.gsc-result")) {
+            const links = node.querySelectorAll("a")
+            for (const link of links) {
+              if (!link._boundToController) continue
+
+              link.removeEventListener("click", this._onClickLink)
+              delete link._boundToController
+            }
+          } else if (node.matches("div.gs-mobilePreview img.gs-imagePreview")) {
+            const link = node.parentElement
+            if (!link._boundToController) continue
+
+            link.removeEventListener("click", this._onClickLink)
+            delete link._boundToController
           }
         }
       }
@@ -37,6 +73,7 @@ export default class extends Controller {
   }
 
   disconnect() {
-    this.searchResultsObserver.disconnect()
+    this._observer?.disconnect()
+    this._abort?.abort()
   }
 }

--- a/app/views/recipes/web_result.html.erb
+++ b/app/views/recipes/web_result.html.erb
@@ -1,5 +1,12 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl text-secondary">Import Recipe</h1>
+  <div class="flex flex-row justify-between items-center">
+    <h1 class="font-bold text-4xl text-secondary">Import Recipe</h1>
+    <% if @recipe.source.present? %>
+      <%= link_to URI(@recipe.source).to_s, target: "_blank", rel: "noopener" do %>
+        <%= render_icon "mini/link" %>
+      <% end %>
+    <% end %>
+  </div>
 
   <%= render "form", recipe: @recipe %>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Updates the stimulus controller which overrides the click action for search result links. This change was prompted to support image search results.

All links now go to the web result import page. A link to the recipe source was added to the import page.

<!--- Include screenshots if appropriate -->

<img width="942" height="435" alt="image" src="https://github.com/user-attachments/assets/99b27b84-be60-4925-8193-296236ccab96" />

https://github.com/user-attachments/assets/4ca6dccb-0268-468d-8740-e06339d93729

## Testing
<!--- Please describe in detail how you tested your changes -->