### PR TITLE
Don't override ActiveStorage routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get '*unmatched_route', to: 'application#not_found'
+  get '*unmatched_route', to: 'application#not_found', constraints: lambda { |req|
+    req.path.exclude? 'rails/active_storage'
+  }
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The catch-all route was taking precedence over active storage routes, causing images to not load.

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->

Issue was reproduceable in development environment. Verified that images work after modifying the route.