### PR TITLE
Handle array for recipe yield

### DIFF
--- a/lib/recipes/import/json_schema.rb
+++ b/lib/recipes/import/json_schema.rb
@@ -27,7 +27,9 @@ module Recipes
       end
 
       def recipe_yield
-        recipe_json['recipeYield']
+        return if recipe_json['recipeYield'].blank?
+
+        Array.wrap(recipe_json['recipeYield']).first
       end
 
       def recipe_prep_time

--- a/spec/lib/recipes/import/json_schema_spec.rb
+++ b/spec/lib/recipes/import/json_schema_spec.rb
@@ -108,6 +108,21 @@ RSpec.describe Recipes::Import::JsonSchema do
     it 'extracts the recipe yield' do
       expect(import.recipe_yield).to eq(recipe_yield)
     end
+
+    context 'when yield is an array' do
+      let(:field_json) do
+        <<~JSON
+          "recipeYield": [
+            "6 servings",
+            "12 pieces"
+          ]
+        JSON
+      end
+
+      it 'extracts the first yield value' do
+        expect(import.recipe_yield).to eq('6 servings')
+      end
+    end
   end
 
   describe '#recipe_prep_time' do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

<img width="119" height="51" alt="image" src="https://github.com/user-attachments/assets/c6e3fda1-6e3c-4999-8d98-5316808f2c74" />

Saw some recipes importing with an odd yield. The JSON for these were arrays.

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->

Added test to check for this condition