### PR TITLE
Restrict access to admin routes

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -3,14 +3,14 @@ module Admin
     include Clearance::Controller
 
     before_action :require_login
-    # before_action :require_admin
+    before_action :require_admin
 
-    # private
+    private
 
-    # def require_admin
-    #   return if current_user&.is_admin?
+    def require_admin
+      return if current_user&.is_admin?
 
-    #   render file: Rails.root.join(Rails.public_path, '404.html'), status: :not_found, layout: false
-    # end
+      render file: Rails.root.join(Rails.public_path, '404.html'), status: :not_found, layout: false
+    end
   end
 end

--- a/spec/support/shared_examples/admin_route.rb
+++ b/spec/support/shared_examples/admin_route.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples 'an admin-only route' do |verb, path_or_proc, params = {}|
       public_send(verb, resolve_path(path_or_proc), params: params)
     end
 
-    it 'denies access', skip: 'admin restriction temporarily disabled' do
+    it 'denies access' do
       expect(response).to have_http_status(:not_found)
     end
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Only allows admin user access to the admin routes

<!--- Include screenshots if appropriate -->

## Testing
<!--- Please describe in detail how you tested your changes -->
Verified non-admin user cannot access admin dashboards
<img width="953" height="332" alt="image" src="https://github.com/user-attachments/assets/9e2e10ea-8076-4424-ba0f-7d086197c45c" />
