### PR TITLE
Cleanup Categories

### DIFF
--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -1,0 +1,8 @@
+module RecipesHelper
+  def category_select_options(recipe)
+    existing_categories = Category.all.map { |c| [c.name, c.name] }
+    pending_categories = (recipe.pending_category_names || []).map { |n| [n, n] }
+
+    (existing_categories + pending_categories).uniq { |label, _value| label.to_s.downcase }
+  end
+end

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -70,7 +70,7 @@
   </div>
 
   <div class="my-5 lg:my-2 relative">
-    <%= form.collection_select :category_names, Category.all, :name, :name, {}, { data: { controller: "tom-select", 'tom-select-create-value': true }, multiple: true, placeholder: "Add Categories" } %>
+    <%= form.select :category_names, category_select_options(recipe), {}, { data: { controller: "tom-select", 'tom-select-create-value': true }, multiple: true, placeholder: "Add Categories" } %>
   </div>
 
   <div class="my-10 relative">

--- a/db/migrate/20260202000000_remove_orphaned_categories.rb
+++ b/db/migrate/20260202000000_remove_orphaned_categories.rb
@@ -1,0 +1,15 @@
+class RemoveOrphanedCategories < ActiveRecord::Migration[7.2]
+  def up
+    # Delete categories that have no associated recipes
+    execute <<-SQL
+      DELETE FROM categories
+      WHERE id NOT IN (
+        SELECT DISTINCT category_id FROM categories_recipes
+      )
+    SQL
+  end
+
+  def down
+    # No-op: Cannot restore deleted categories. This migration is one-way.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_01_022014) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_02_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/recipes/import/json_schema.rb
+++ b/lib/recipes/import/json_schema.rb
@@ -45,7 +45,11 @@ module Recipes
       end
 
       def recipe_category_names
-        (Array.wrap(recipe_json['recipeCategory']) + Array.wrap(recipe_json['recipeCuisine'])).compact_blank
+        (Array.wrap(recipe_json['recipeCategory']) + Array.wrap(recipe_json['recipeCuisine']))
+          .map { |name| name.split(',') }
+          .flatten
+          .map { |name| name.strip.titleize }
+          .compact_blank
       end
 
       def recipe_description

--- a/spec/helpers/recipes_helper_spec.rb
+++ b/spec/helpers/recipes_helper_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe RecipesHelper do
+  describe '#category_select_options' do
+    subject(:options) { helper.category_select_options(recipe) }
+
+    let(:recipe) { build(:recipe) }
+    let(:category_names) { [] }
+    let(:pending_category_names) { [] }
+    let(:expected_options) do
+      expected_categories
+        .map { |name| [name, name] }
+    end
+
+    before do
+      Category.from_names(category_names)
+      recipe.pending_category_names = pending_category_names
+    end
+
+    context 'when there are only existing categories' do
+      let(:category_names) { %w[Main Dessert] }
+      let(:expected_categories) { category_names }
+
+      it 'returns existing categories as select options' do
+        expect(options).to match_array(expected_options)
+      end
+    end
+
+    context 'when there are pending category names' do
+      let(:pending_category_names) { %w[French Appetizer] }
+      let(:expected_categories) { pending_category_names }
+
+      it 'includes pending categories in the options' do
+        expect(options).to match_array(expected_options)
+      end
+    end
+
+    context 'when there are both existing and pending categories' do
+      let(:category_names) { %w[Main] }
+      let(:pending_category_names) { %w[French Appetizer] }
+      let(:expected_categories) { (category_names + pending_category_names) }
+
+      it 'combines existing and pending categories' do
+        expect(options).to match_array(expected_options)
+      end
+    end
+
+    context 'when there are duplicate category names' do
+      let(:category_names) { %w[Main] }
+      let(:pending_category_names) { %w[Main French] }
+      let(:expected_categories) { %w[Main French] }
+
+      it 'removes duplicates' do
+        expect(options).to match_array(expected_options)
+      end
+    end
+
+    context 'when there are no categories' do
+      let(:expected_categories) { [] }
+
+      it 'returns an empty array' do
+        expect(options).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/recipes/import/base_spec.rb
+++ b/spec/lib/recipes/import/base_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Recipes::Import::Base do
       yield: '4 servings',
       prep_time: '30',
       cook_time: '60',
+      category_names: %w[Main Italian],
       description: 'A test recipe',
       ingredients: 'Ingredient 1',
       directions: 'Step 1',

--- a/spec/models/recipes_spec.rb
+++ b/spec/models/recipes_spec.rb
@@ -21,38 +21,64 @@ RSpec.describe Recipe do
   end
 
   describe '#category_names=' do
-    subject(:described_method) { recipe.category_names = category_names }
+    subject(:set_category_names) { recipe.category_names = category_names }
 
-    let(:recipe) { create(:recipe, name: 'Spaghetti') }
+    let(:recipe) { build(:recipe, name: 'Spaghetti') }
     let(:category_names) { %w[Pasta Italian Main] }
 
     context 'when there are no categories' do
-      it 'creates the categories' do
-        expect { described_method }.to change(Category, :count).by(3)
+      it 'does not create the categories immediately' do
+        expect { set_category_names }.not_to change(Category, :count)
       end
 
-      it 'adds the categories to the recipe' do
-        expect { described_method }.to change { recipe.categories.count }.by(3)
+      it 'creates the categories on save' do
+        set_category_names
+
+        expect { recipe.save! }.to change(Category, :count).by(3)
+      end
+
+      it 'adds the categories to the recipe on save' do
+        set_category_names
+        recipe.save!
+
+        expect(recipe.reload.categories.map(&:name)).to match_array(category_names)
       end
     end
 
     context 'when the recipe already has categories' do
-      before { recipe.categories << Category.from_names(existing_categories) }
-
       let(:existing_categories) { %w[Main Vegetarian] }
 
-      it 'changes the categories to match the names exactly' do
-        expect { described_method }
-          .to change { recipe.categories.map(&:name) }
+      before { recipe.categories = Category.from_names(existing_categories) }
+
+      it 'does not change categories immediately' do
+        expect { set_category_names }
+          .not_to change { recipe.categories.map(&:name) }
           .from(match_array(existing_categories))
-          .to match_array(category_names)
+      end
+
+      it 'changes the categories to match the names exactly on save' do
+        expect(recipe.categories.map(&:name)).to match_array(existing_categories)
+
+        set_category_names
+        recipe.save!
+
+        expect(recipe.reload.categories.map(&:name)).to match_array(category_names)
+      end
+
+      it 'only creates missing categories on save' do
+        set_category_names
+
+        expect { recipe.save! }.to change(Category, :count).by(2)
       end
 
       context 'when given an empty array' do
         let(:category_names) { [] }
 
-        it 'removes all categories' do
-          expect { described_method }.to change { recipe.categories.count }.from(2).to(0)
+        it 'removes all categories on save' do
+          set_category_names
+          recipe.save!
+
+          expect(recipe.reload.categories).to be_empty
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Fixes an issue where imports were not setting categories on the recipe but were creating them in the database.

The desired behavior is to populate the categories in the dropdown, but not add them to the database until the recipe is saved. This will avoid creating the categories if the recipe ends up not getting saved or the user removes the categories from the dropdown before saving.

There is also a database migration to delete any categories which are not assigned to any recipes

<!--- Include screenshots if appropriate -->

<img width="938" height="470" alt="image" src="https://github.com/user-attachments/assets/91986855-a706-48ee-9b2d-14e81a31fbfd" />

## Testing
<!--- Please describe in detail how you tested your changes -->

Created some categories from rails console, ran migration and verified that only the unused categories were removed.

Tested recipe imports, verified that categories were populated in the form but not created in the database until after the recipe was saved.