### PR TITLE
Add admin link

### DIFF
--- a/app/views/icons/mini/_key.html.erb
+++ b/app/views/icons/mini/_key.html.erb
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5 <%= classes %>">
+  <path fill-rule="evenodd" d="M8 7a5 5 0 1 1 3.61 4.804l-1.903 1.903A1 1 0 0 1 9 14H8v1a1 1 0 0 1-1 1H6v1a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-2a1 1 0 0 1 .293-.707L8.196 8.39A5.002 5.002 0 0 1 8 7Zm5-3a.75.75 0 0 0 0 1.5A1.5 1.5 0 0 1 14.5 7 .75.75 0 0 0 16 7a3 3 0 0 0-3-3Z" clip-rule="evenodd" />
+</svg>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -59,6 +59,22 @@
               <span class="absolute bottom-0 left-3 right-3 h-0.5 bg-secondary transform origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300"></span>
             <% end %>
           </li>
+          <% if current_user&.is_admin? %>
+            <li>
+              <%= link_to admin_root_path, class: "group relative block flex items-center mt-3 px-3 text-gray-200" do %>
+                <span class="flex items-center">
+                  <%= render_icon "mini/key", classes: "mx-1 transition-colors duration-300 group-hover:text-secondary" %>
+                  <span class="relative overflow-hidden">
+                    <span class="block transition-colors duration-300 group-hover:text-transparent">Admin</span>
+                    <span class="absolute inset-0 text-secondary transform origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300 flex items-center">
+                      Admin
+                    </span>
+                  </span>
+                </span>
+                <span class="absolute bottom-0 left-3 right-3 h-0.5 bg-secondary transform origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-300"></span>
+              <% end %>
+            </li>
+          <% end %>
           <li>
             <%= button_to sign_out_path, method: :delete, class: "group relative inline-flex lg:border-l-2 border-gray-200 text-stroke-3 stroke-gray-200 text-gray-200 items-center mt-3 px-3" do %>
               <span class="relative z-10 flex items-center">

--- a/spec/features/navigation/admin_link_spec.rb
+++ b/spec/features/navigation/admin_link_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin link in navbar' do
+  given(:home_page) { HomePage.new }
+
+  scenario 'is hidden for non-admin users' do
+    user = create(:user)
+
+    visit root_path(as: user)
+
+    expect(home_page).to have_no_admin_link
+  end
+
+  scenario 'is visible for admin users' do
+    admin = create(:user, is_admin: true)
+
+    visit root_path(as: admin)
+
+    expect(home_page).to have_admin_link
+  end
+end

--- a/spec/support/pages/base_page.rb
+++ b/spec/support/pages/base_page.rb
@@ -2,6 +2,7 @@ class BasePage < SitePrism::Page
   element :new_recipe_link, 'a[href="/recipes/new"]'
   element :web_search_link, 'a[href="/recipes/web_search"]'
   element :archive_upload_link, 'a[href="/recipes/archive/upload"]'
+  element :admin_link, 'a[href="/admin"]'
   element :sign_in_link, 'a[href="/sign_in"]'
   element :sign_out_button, 'button', text: I18n.t('layouts.application.sign_out')
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Adds link to admin in the navbar. This should only show if the logged in user is an admin.

I'm open to suggestions for using a different icon.

<!--- Include screenshots if appropriate -->

<img width="949" height="259" alt="image" src="https://github.com/user-attachments/assets/37377fee-a54a-4e45-8a71-dadcd86c6086" />

<img width="448" height="290" alt="image" src="https://github.com/user-attachments/assets/7d2944c7-4dca-4f2c-a999-639614ec3594" />


## Testing
<!--- Please describe in detail how you tested your changes -->