### PR TITLE
Move form buttons to fixed container on mobile

### DIFF
--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -1,5 +1,5 @@
 
-<%= form_with(model: recipe, class: "contents") do |form| %>
+<%= form_with(model: recipe, class: "contents", id: "recipe_form") do |form| %>
   <% if recipe.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(recipe.errors.count, "error") %> prohibited this recipe from being saved:</h2>
@@ -110,10 +110,5 @@
     </div>
   </div>
 
-  <div class="inline relative">
-    <%= form.hidden_field :source %>
-    <%= button_tag(class: "inline-flex items-center rounded-lg py-2 px-3 bg-white hover:bg-secondary text-secondary hover:text-white border border-secondary inline-block font-medium cursor-pointer") do %>
-      <%= render_icon "micro/document_check", classes: "me-1" %> Save
-    <% end %>
-  </div>
+  <%= form.hidden_field :source %>
 <% end %>

--- a/app/views/recipes/edit.html.erb
+++ b/app/views/recipes/edit.html.erb
@@ -2,8 +2,13 @@
   <h1 class="font-bold text-2xl lg:text-4xl text-secondary text-start">Editing recipe</h1>
 
   <%= render "form", recipe: @recipe %>
+</div>
 
-  <%= link_to @recipe, class: "inline-flex items-center rounded-lg py-2 px-3 bg-white hover:bg-secondary text-secondary hover:text-white border border-secondary inline-block font-medium cursor-pointer" do %>
+<div class="pt-0 lg:pt-4 lg:px-8 edit-delete-container shadow-xl lg:shadow-none fixed bottom-0 lg:static bg-black lg:bg-transparent w-screen lg:w-8/12 inset-x-0 lg:inset-auto mx-0 lg:mx-auto flex flex-row justify-center lg:justify-start gap-2 z-50 lg:z-auto">
+  <%= button_tag(form: "recipe_form", class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white") do %>
+    <%= render_icon "micro/document_check", classes: "me-1" %> Save
+  <% end %>
+  <%= link_to @recipe, class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white" do %>
     <%= render_icon "micro/arrow_uturn_left", classes: "me-1" %> Cancel
   <% end %>
 </div>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -1,10 +1,14 @@
 <div class="mx-auto md:w-4/5 w-full form-container lg:px-20 p-5">
-
   <h1 class="font-bold text-2xl lg:text-4xl text-secondary text-start">Create your recipe</h1>
 
   <%= render "form", recipe: @recipe %>
+</div>
 
-  <%= link_to recipes_path, class: "inline-flex items-center ml-2 rounded-lg py-2 px-3 inline-block font-medium text-secondary hover:text-white border border-secondary hover:bg-secondary" do %>
+<div class="pt-0 lg:pt-4 lg:px-8 edit-delete-container shadow-xl lg:shadow-none fixed bottom-0 lg:static bg-black lg:bg-transparent w-screen lg:w-8/12 inset-x-0 lg:inset-auto mx-0 lg:mx-auto flex flex-row justify-center lg:justify-start gap-2 z-50 lg:z-auto">
+  <%= button_tag(form: "recipe_form", class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white") do %>
+    <%= render_icon "micro/document_check", classes: "me-1" %> Save
+  <% end %>
+  <%= link_to recipes_path, class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white" do %>
     <%= render_icon "micro/arrow_uturn_left", classes: "me-1" %> Cancel
   <% end %>
 </div>

--- a/app/views/recipes/web_result.html.erb
+++ b/app/views/recipes/web_result.html.erb
@@ -1,4 +1,4 @@
-<div class="mx-auto md:w-2/3 w-full">
+<div class="mx-auto md:w-2/3 w-full form-container">
   <div class="flex flex-row justify-between items-center">
     <h1 class="font-bold text-4xl text-secondary">Import Recipe</h1>
     <% if @recipe.source.present? %>
@@ -9,8 +9,13 @@
   </div>
 
   <%= render "form", recipe: @recipe %>
+</div>
 
-  <%= link_to 'javascript:history.back()', class: "inline-flex items-center rounded-lg py-2 px-3 bg-white hover:bg-secondary text-secondary hover:text-white border border-secondary inline-block font-medium cursor-pointer" do %>
+<div class="pt-0 lg:pt-4 lg:px-8 edit-delete-container shadow-xl lg:shadow-none fixed bottom-0 lg:static bg-black lg:bg-transparent w-screen lg:w-8/12 inset-x-0 lg:inset-auto mx-0 lg:mx-auto flex flex-row justify-center lg:justify-start gap-2 z-50 lg:z-auto">
+  <%= button_tag(form: "recipe_form", class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white") do %>
+    <%= render_icon "micro/document_check", classes: "me-1" %> Save
+  <% end %>
+  <%= link_to 'javascript:history.back()', class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white" do %>
     <%= render_icon "micro/arrow_uturn_left", classes: "me-1" %> Back
   <% end %>
 </div>

--- a/spec/features/recipes/user_creates_a_recipe_spec.rb
+++ b/spec/features/recipes/user_creates_a_recipe_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'User creates a recipe' do
   scenario 'successfully' do
     home_page.new_recipe_link.click
 
-    new_recipe_page.recipe_form.save_recipe(recipe_data)
+    new_recipe_page.save_recipe(recipe_data)
 
     expect(home_page).to have_content('Recipe was successfully created.')
     user_sees_recipe(recipe_data)

--- a/spec/features/recipes/user_edits_a_recipe_spec.rb
+++ b/spec/features/recipes/user_edits_a_recipe_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'User edits a recipe' do
     home_page.recipe_link(recipe.name).click
 
     recipe_show_page.edit_button.click
-    edit_recipe_page.recipe_form.save_recipe(recipe_data)
+    edit_recipe_page.save_recipe(recipe_data)
 
     expect(home_page).to have_content('Recipe was successfully updated.')
     expect(recipe_show_page.recipe_name).to have_text(recipe_data[:name])

--- a/spec/support/pages/edit_recipe_page.rb
+++ b/spec/support/pages/edit_recipe_page.rb
@@ -4,5 +4,15 @@ class EditRecipePage < BasePage
   set_url '/recipes/{id}/edit'
 
   section :recipe_form, RecipeForm, '.form-container'
+  element :save_button, 'button', text: 'Save'
   element :cancel_button, :link, 'Cancel'
+
+  def submit_form
+    save_button.click
+  end
+
+  def save_recipe(recipe_data)
+    recipe_form.fill_form(recipe_data)
+    submit_form
+  end
 end

--- a/spec/support/pages/new_recipe_page.rb
+++ b/spec/support/pages/new_recipe_page.rb
@@ -4,4 +4,14 @@ class NewRecipePage < BasePage
   set_url '/recipes/new'
 
   section :recipe_form, RecipeForm, '.form-container'
+  element :save_button, 'button', text: 'Save'
+
+  def submit_form
+    save_button.click
+  end
+
+  def save_recipe(recipe_data)
+    recipe_form.fill_form(recipe_data)
+    submit_form
+  end
 end

--- a/spec/support/pages/recipe_form.rb
+++ b/spec/support/pages/recipe_form.rb
@@ -10,7 +10,6 @@ class RecipeForm < SitePrism::Section
   element :directions_field, '[name="recipe[directions]"]'
   element :notes_field, '[name="recipe[notes]"]'
   element :rating_container, '#recipe_rating'
-  element :save_button, 'button', text: 'Save'
 
   TEXT_FIELDS = %i[name yield prep_time cook_time total_time description ingredients directions notes].freeze
 
@@ -37,14 +36,5 @@ class RecipeForm < SitePrism::Section
       setter = "#{field}_value="
       send(setter, value) if respond_to?(setter)
     end
-  end
-
-  def submit_form
-    save_button.click
-  end
-
-  def save_recipe(recipe_data)
-    fill_form(recipe_data)
-    submit_form
   end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Consistently uses fixed container on bottom of page for recipe actions

<!--- Include screenshots if appropriate -->

<img width="282" height="503" alt="image" src="https://github.com/user-attachments/assets/c7e09265-cd91-4035-b596-3689c1fc001c" />

<img width="281" height="503" alt="image" src="https://github.com/user-attachments/assets/76bee556-c4d1-4804-8aa3-c06085e666ff" />

<img width="281" height="502" alt="image" src="https://github.com/user-attachments/assets/05e9a02f-f18d-49fb-b634-a0f811cd1239" />

## Testing
<!--- Please describe in detail how you tested your changes -->