### PR TITLE
Use local storage to save recipe draft

### DIFF
--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -1,4 +1,10 @@
 module RecipesHelper
+  def recipe_draft_key(recipe)
+    draft_id = recipe.persisted? ? recipe.id : 'new'
+
+    "user:#{current_user.id}:recipe:#{draft_id}"
+  end
+
   def category_select_options(recipe)
     user = recipe.user || current_user
     existing_categories = user.categories.pluck(:name)

--- a/app/javascript/controllers/recipe_draft_controller.js
+++ b/app/javascript/controllers/recipe_draft_controller.js
@@ -1,0 +1,191 @@
+import { Controller } from "@hotwired/stimulus"
+import debounce from "lodash/debounce"
+import {
+  readRecipeDraft,
+  removeRecipeDraft,
+  storageAvailable,
+  writeRecipeDraft,
+} from "./recipe_draft_storage"
+
+export default class extends Controller {
+  static values = {
+    storageKey: String,
+  }
+
+  connect() {
+    if (!storageAvailable()) return
+    if (!this.hasStorageKeyValue || this.storageKeyValue.length === 0) return
+
+    this.persistenceEnabled = true
+
+    this.draft = this.readDraft()
+
+    this.restoreDraft()
+
+    this.debouncedPersistDraft = debounce(() => this.persistDraft(), 300)
+    this.boundHandleInput = this.handleInput.bind(this)
+    this.boundHandleChange = this.handleChange.bind(this)
+
+    this.element.addEventListener("input", this.boundHandleInput)
+    this.element.addEventListener("change", this.boundHandleChange)
+  }
+
+  disconnect() {
+    if (this.boundHandleInput) {
+      this.element.removeEventListener("input", this.boundHandleInput)
+    }
+
+    if (this.boundHandleChange) {
+      this.element.removeEventListener("change", this.boundHandleChange)
+    }
+
+    if (this.debouncedPersistDraft) {
+      this.debouncedPersistDraft.cancel()
+    }
+  }
+
+  submitEnd(event) {
+    if (event.detail.success) {
+      this.clearDraft()
+    }
+  }
+
+  handleInput(event) {
+    if (!this.persistenceEnabled) return
+    this.clearOutlineHighlight(event.target)
+    if (!this.updateDraftForElement(event.target)) return
+
+    this.debouncedPersistDraft()
+  }
+
+  handleChange(event) {
+    if (!this.persistenceEnabled) return
+    this.clearOutlineHighlight(event.target)
+    if (!this.updateDraftForElement(event.target)) return
+
+    this.debouncedPersistDraft.cancel()
+    this.persistDraft()
+  }
+
+  persistDraft() {
+    if (!this.persistenceEnabled) return
+
+    try {
+      writeRecipeDraft(this.storageKeyValue, this.draft)
+      this.clearAllOutlineHighlights()
+    } catch (error) {
+      console.error(
+        "Failed to persist recipe draft, auto-save has been disabled:",
+        error,
+      )
+      this.disablePersistence()
+      this.draft = {}
+    }
+  }
+
+  restoreDraft() {
+    const draft = this.draft
+    if (!draft || Object.keys(draft).length === 0) return false
+
+    this.formElements().forEach((element) => {
+      if (this.isIgnoredField(element)) return
+      if (!(element.name in draft)) return
+
+      const value = this.normalizedFieldValue(draft[element.name])
+
+      if (!this.valuesEqual(element.value, value)) {
+        this.applyOutlineHighlight(element)
+      }
+
+      element.value = value
+    })
+
+    return true
+  }
+
+  clearDraft() {
+    if (this.debouncedPersistDraft) {
+      this.debouncedPersistDraft.cancel()
+    }
+
+    this.draft = {}
+    if (this.persistenceEnabled) {
+      removeRecipeDraft(this.storageKeyValue)
+    }
+  }
+
+  disablePersistence() {
+    this.persistenceEnabled = false
+
+    if (this.debouncedPersistDraft) {
+      this.debouncedPersistDraft.cancel()
+    }
+  }
+
+  readDraft() {
+    return readRecipeDraft(this.storageKeyValue)
+  }
+
+  formElements() {
+    return Array.from(this.element.elements)
+  }
+
+  isIgnoredField(element) {
+    if (!element?.name) return true
+
+    const ignoredNames = ["authenticity_token", "commit", "utf8", "_method"]
+    if (ignoredNames.includes(element.name)) return true
+
+    const ignoredTypes = [
+      "file",
+      "hidden",
+      "submit",
+      "button",
+      "image",
+      "reset",
+      "checkbox",
+      "radio",
+    ]
+    if (ignoredTypes.includes(element.type)) return true
+
+    const ignoredTagNames = ["SELECT"]
+    if (ignoredTagNames.includes(element.tagName)) return true
+
+    return false
+  }
+
+  updateDraftForElement(element) {
+    if (this.isIgnoredField(element)) return false
+
+    this.draft[element.name] = this.normalizedFieldValue(element.value)
+    return true
+  }
+
+  valuesEqual(left, right) {
+    return this.normalizedFieldValue(left) === this.normalizedFieldValue(right)
+  }
+
+  normalizedFieldValue(value) {
+    if (value === null || value === undefined) return ""
+
+    return String(value)
+  }
+
+  applyOutlineHighlight(element) {
+    element.style.outline = "2px solid rgb(239 68 68)"
+    element.style.outlineOffset = "1px"
+  }
+
+  clearOutlineHighlight(element) {
+    if (!element) return
+
+    element.style.outline = ""
+    element.style.outlineOffset = ""
+  }
+
+  clearAllOutlineHighlights() {
+    this.formElements().forEach((element) => {
+      this.clearOutlineHighlight(element)
+    })
+  }
+}

--- a/app/javascript/controllers/recipe_draft_maintenance_controller.js
+++ b/app/javascript/controllers/recipe_draft_maintenance_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+import {
+  runRecipeDraftMaintenance,
+  storageAvailable,
+} from "./recipe_draft_storage"
+
+export default class extends Controller {
+  connect() {
+    if (!storageAvailable()) return
+
+    runRecipeDraftMaintenance()
+  }
+}

--- a/app/javascript/controllers/recipe_draft_notice_controller.js
+++ b/app/javascript/controllers/recipe_draft_notice_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+import {
+  hasRecipeDraft,
+  removeRecipeDraft,
+  storageAvailable,
+} from "./recipe_draft_storage"
+
+export default class extends Controller {
+  static values = {
+    storageKey: String,
+  }
+
+  static targets = ["notice"]
+
+  connect() {
+    if (!storageAvailable()) return
+
+    this.toggleNotice(this.hasStoredDraft())
+  }
+
+  clearAndReload(event) {
+    event.preventDefault()
+    if (!this.hasStorageKeyValue || this.storageKeyValue.length === 0) return
+
+    removeRecipeDraft(this.storageKeyValue)
+
+    if (window.Turbo && typeof window.Turbo.visit === "function") {
+      window.Turbo.visit(window.location.href, { action: "replace" })
+    } else {
+      window.location.reload()
+    }
+  }
+
+  hasStoredDraft() {
+    if (!this.hasStorageKeyValue || this.storageKeyValue.length === 0)
+      return false
+
+    return hasRecipeDraft(this.storageKeyValue)
+  }
+
+  toggleNotice(visible) {
+    if (!this.hasNoticeTarget) return
+
+    this.noticeTarget.hidden = !visible
+  }
+}

--- a/app/javascript/controllers/recipe_draft_storage.js
+++ b/app/javascript/controllers/recipe_draft_storage.js
@@ -1,0 +1,118 @@
+const DRAFT_STORAGE_PREFIX = "recipe_draft:storage:"
+const MAINTENANCE_KEY = "recipe_draft:maintenance"
+const TEST_KEY = "recipe_draft:test"
+
+const MAINTENANCE_INTERVAL_MS = 24 * 60 * 60 * 1000 // 24 hours
+const DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+export function storageAvailable() {
+  try {
+    localStorage.setItem(TEST_KEY, TEST_KEY)
+    localStorage.removeItem(TEST_KEY)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function hasRecipeDraft(recipeKey) {
+  const recipeDraft = readRecipeDraft(recipeKey)
+  if (Object.keys(recipeDraft).length === 0) return false
+
+  return true
+}
+
+export function readRecipeDraft(recipeKey) {
+  const storageKey = recipeStorageKey(recipeKey)
+  const recipeDraft = loadRecipeDraft(storageKey)
+  if (!recipeDraft) return {}
+
+  if (!isValidRecipeDraft(recipeDraft)) {
+    removeRecipeDraft(recipeKey)
+    return {}
+  }
+
+  return recipeDraft.fields
+}
+
+export function writeRecipeDraft(recipeKey, fields) {
+  localStorage.setItem(
+    recipeStorageKey(recipeKey),
+    JSON.stringify({
+      updatedAt: Date.now(),
+      fields,
+    }),
+  )
+}
+
+export function removeRecipeDraft(recipeKey) {
+  const storageKey = recipeStorageKey(recipeKey)
+  localStorage.removeItem(storageKey)
+}
+
+function recipeStorageKey(recipeKey) {
+  return `${DRAFT_STORAGE_PREFIX}${recipeKey}`
+}
+
+function loadRecipeDraft(storageKey) {
+  const rawValue = localStorage.getItem(storageKey)
+  if (!rawValue) return null
+
+  try {
+    return JSON.parse(rawValue)
+  } catch {
+    localStorage.removeItem(storageKey)
+    return null
+  }
+}
+
+function isValidRecipeDraft(recipeDraft) {
+  return (
+    recipeDraft &&
+    typeof recipeDraft === "object" &&
+    recipeDraft.fields &&
+    typeof recipeDraft.fields === "object" &&
+    "updatedAt" in recipeDraft &&
+    isActiveRecipeDraft(recipeDraft)
+  )
+}
+
+function isActiveRecipeDraft(recipeDraft) {
+  const updatedAt = Number(recipeDraft.updatedAt)
+  if (!Number.isFinite(updatedAt)) return false
+
+  return Date.now() - updatedAt <= DRAFT_MAX_AGE_MS
+}
+
+export function runRecipeDraftMaintenance() {
+  if (!shouldRunMaintenance()) return
+
+  draftStorageKeys().forEach((storageKey) => {
+    const recipeDraft = loadRecipeDraft(storageKey)
+    if (isValidRecipeDraft(recipeDraft)) return
+
+    localStorage.removeItem(storageKey)
+  })
+
+  localStorage.setItem(MAINTENANCE_KEY, String(Date.now()))
+}
+
+function draftStorageKeys() {
+  const keys = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const storageKey = localStorage.key(i)
+    if (storageKey !== null && storageKey.startsWith(DRAFT_STORAGE_PREFIX)) {
+      keys.push(storageKey)
+    }
+  }
+  return keys
+}
+
+function shouldRunMaintenance() {
+  const lastRunAt = Number(localStorage.getItem(MAINTENANCE_KEY))
+
+  // if not set or invalid, maintenance should be run
+  if (!Number.isFinite(lastRunAt)) return true
+
+  return Date.now() - lastRunAt > MAINTENANCE_INTERVAL_MS
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,9 @@
     <%= stylesheet_link_tag "application", 'data-turbo-track': "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="bg-gray-50">
+  <body
+    class="bg-gray-50"
+    data-controller="recipe-draft-maintenance">
     <header>
       <%= render "layouts/navigation" %>
     </header>

--- a/app/views/recipes/_draft_notice.html.erb
+++ b/app/views/recipes/_draft_notice.html.erb
@@ -1,0 +1,12 @@
+<div
+  hidden
+  data-controller="recipe-draft-notice"
+  data-recipe-draft-notice-target="notice"
+  data-recipe-draft-notice-storage-key-value="<%= storage_key %>"
+  class="flex justify-center text-xs">
+  <div class="flash border py-2 px-3 m-1 font-medium rounded-lg inline-block bg-gray-50 text-gray-500 border-gray-600">
+    <div class="flex items-center justify-between gap-2">
+      <%= yield %>
+    </div>
+  </div>
+</div>

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -1,5 +1,14 @@
+<% if local_assigns.fetch(:draft_enabled, true) %>
+  <% form_data = {
+       controller: 'recipe-draft',
+       action: 'turbo:submit-end->recipe-draft#submitEnd',
+       'recipe-draft-storage-key-value': recipe_draft_key(recipe)
+     } %>
+<% else %>
+  <% form_data = nil %>
+<% end %>
 
-<%= form_with(model: recipe, class: "contents", id: "recipe_form") do |form| %>
+<%= form_with(model: recipe, class: "contents", id: "recipe_form", data: form_data) do |form| %>
   <% if recipe.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
       <h2><%= pluralize(recipe.errors.count, "error") %> prohibited this recipe from being saved:</h2>

--- a/app/views/recipes/_form_page.html.erb
+++ b/app/views/recipes/_form_page.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto md:w-4/5 w-full form-container lg:px-20 px-5 pb-5 pt-0">
+  <%= render "draft_notice", storage_key: recipe_draft_key(recipe) do %>
+    <span>Loaded unsaved changes.</span>
+    <button
+      type="button"
+      class="text-red-600 hover:text-red-700 hover:underline font-medium cursor-pointer"
+      data-action="recipe-draft-notice#clearAndReload">
+      Discard
+    </button>
+  <% end %>
+
+  <h1 class="font-bold text-2xl lg:text-4xl text-secondary text-start"><%= title %></h1>
+
+  <%= render "form", recipe: recipe %>
+</div>

--- a/app/views/recipes/edit.html.erb
+++ b/app/views/recipes/edit.html.erb
@@ -1,14 +1,10 @@
-<div class="mx-auto md:w-4/5 w-full form-container lg:px-20 p-5">
-  <h1 class="font-bold text-2xl lg:text-4xl text-secondary text-start">Editing recipe</h1>
-
-  <%= render "form", recipe: @recipe %>
-</div>
+<%= render "form_page", recipe: @recipe, title: "Editing recipe" %>
 
 <div class="pt-0 lg:pt-4 lg:px-8 edit-delete-container shadow-xl lg:shadow-none fixed bottom-0 lg:static bg-black lg:bg-transparent w-screen lg:w-8/12 inset-x-0 lg:inset-auto mx-0 lg:mx-auto flex flex-row justify-center lg:justify-start gap-2 z-50 lg:z-auto">
   <%= button_tag(form: "recipe_form", class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white") do %>
     <%= render_icon "micro/document_check", classes: "me-1" %> Save
   <% end %>
   <%= link_to @recipe, class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white" do %>
-    <%= render_icon "micro/arrow_uturn_left", classes: "me-1" %> Cancel
+    <%= render_icon "micro/arrow_uturn_left", classes: "me-1" %> Back
   <% end %>
 </div>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -1,14 +1,10 @@
-<div class="mx-auto md:w-4/5 w-full form-container lg:px-20 p-5">
-  <h1 class="font-bold text-2xl lg:text-4xl text-secondary text-start">Create your recipe</h1>
-
-  <%= render "form", recipe: @recipe %>
-</div>
+<%= render "form_page", recipe: @recipe, title: "Create your recipe" %>
 
 <div class="pt-0 lg:pt-4 lg:px-8 edit-delete-container shadow-xl lg:shadow-none fixed bottom-0 lg:static bg-black lg:bg-transparent w-screen lg:w-8/12 inset-x-0 lg:inset-auto mx-0 lg:mx-auto flex flex-row justify-center lg:justify-start gap-2 z-50 lg:z-auto">
   <%= button_tag(form: "recipe_form", class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white") do %>
     <%= render_icon "micro/document_check", classes: "me-1" %> Save
   <% end %>
   <%= link_to recipes_path, class: "inline-flex items-center rounded-lg py-2 px-3 bg-transparent border border-transparent text-white hover:text-secondary font-medium cursor-pointer lg:bg-white lg:border-secondary lg:text-secondary lg:hover:bg-secondary lg:hover:text-white" do %>
-    <%= render_icon "micro/arrow_uturn_left", classes: "me-1" %> Cancel
+    <%= render_icon "micro/arrow_uturn_left", classes: "me-1" %> Back
   <% end %>
 </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,3 +1,8 @@
+<%= render "draft_notice", storage_key: recipe_draft_key(@recipe) do %>
+  <span>This recipe has unsaved changes.</span>
+  <%= link_to "Review", edit_recipe_path(@recipe), class: "text-secondary hover:underline" %>
+<% end %>
+
 <div class="form-container lg:w-auto flex flex-col-reverse md:flex-row-reverse lg:flex-col lg:mx-auto justify-center">
   <%= render @recipe %>
   <div class="pt-0 lg:pt-4 lg:px-8 edit-delete-container shadow-xl lg:shadow-none fixed bottom-0 lg:static bg-black lg:bg-transparent w-screen lg:w-8/12 inset-x-0 lg:inset-auto mx-0 lg:mx-auto flex flex-row justify-center lg:justify-start gap-2">

--- a/app/views/recipes/web_result.html.erb
+++ b/app/views/recipes/web_result.html.erb
@@ -8,7 +8,7 @@
     <% end %>
   </div>
 
-  <%= render "form", recipe: @recipe %>
+  <%= render "form", recipe: @recipe, draft_enabled: false %>
 </div>
 
 <div class="pt-0 lg:pt-4 lg:px-8 edit-delete-container shadow-xl lg:shadow-none fixed bottom-0 lg:static bg-black lg:bg-transparent w-screen lg:w-8/12 inset-x-0 lg:inset-auto mx-0 lg:mx-auto flex flex-row justify-center lg:justify-start gap-2 z-50 lg:z-auto">

--- a/spec/features/recipes/user_edits_a_recipe_spec.rb
+++ b/spec/features/recipes/user_edits_a_recipe_spec.rb
@@ -28,12 +28,12 @@ RSpec.feature 'User edits a recipe' do
     expect(recipe_show_page.recipe_name).to have_text(recipe_data[:name])
   end
 
-  scenario 'and clicks cancel' do
+  scenario 'and clicks back' do
     home_page.recipe_link(recipe.name).click
 
     recipe_show_page.edit_button.click
     edit_recipe_page.recipe_form.fill_form(recipe_data)
-    edit_recipe_page.cancel_button.click
+    edit_recipe_page.back_button.click
 
     expect(recipe_show_page.recipe_name).to have_text(recipe.name)
   end

--- a/spec/helpers/recipes_helper_spec.rb
+++ b/spec/helpers/recipes_helper_spec.rb
@@ -1,6 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe RecipesHelper do
+  describe '#recipe_draft_key' do
+    let(:current_user) { create(:user) }
+
+    before do
+      allow(helper).to receive(:current_user).and_return(current_user)
+    end
+
+    context 'when recipe is persisted' do
+      let(:recipe) { create(:recipe, user: current_user) }
+
+      it 'returns a key with the persisted recipe id' do
+        expect(helper.recipe_draft_key(recipe)).to eq("user:#{current_user.id}:recipe:#{recipe.id}")
+      end
+    end
+
+    context 'when recipe is not persisted' do
+      let(:recipe) { build(:recipe, user: current_user) }
+
+      it 'returns a key with new as the recipe id' do
+        expect(helper.recipe_draft_key(recipe)).to eq("user:#{current_user.id}:recipe:new")
+      end
+    end
+  end
+
   describe '#category_select_options' do
     subject(:options) { helper.category_select_options(recipe) }
 

--- a/spec/support/pages/edit_recipe_page.rb
+++ b/spec/support/pages/edit_recipe_page.rb
@@ -5,7 +5,7 @@ class EditRecipePage < BasePage
 
   section :recipe_form, RecipeForm, '.form-container'
   element :save_button, 'button', text: 'Save'
-  element :cancel_button, :link, 'Cancel'
+  element :back_button, :link, 'Back'
 
   def submit_form
     save_button.click


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Stores unsaved changes in user's browser localStorage
- Expires draft after 30 days
- Performs daily maintenance clearing invalid draft recipes
- Alerts user when there are unsaved changes
- Allows user to manually clear draft changes
- Highlights fields with draft changes

Draft excludes hidden fields, image and non-text fields such as categories and rating. Support for categories, rating and other non-text fields can be added in the future if desired, but for now the added complexity didn't seem worth the minimal value that it would add.

<!--- Include screenshots if appropriate -->

<img width="943" height="848" alt="image" src="https://github.com/user-attachments/assets/b2e2f8d8-8877-491a-a966-7e48e108510c" />

<img width="943" height="899" alt="image" src="https://github.com/user-attachments/assets/a48c68d1-3608-4069-a7da-d52cb8fcbf8e" />

<img width="943" height="655" alt="image" src="https://github.com/user-attachments/assets/cbd6ec0e-eabe-4278-b7d4-d6e498cfe187" />

## Testing
<!--- Please describe in detail how you tested your changes -->