### PR TITLE
Docker dev/test improvements

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Prettier
         run: |

--- a/.github/workflows/rails-docker-ci.yml
+++ b/.github/workflows/rails-docker-ci.yml
@@ -1,0 +1,70 @@
+name: Rails Docker CI
+
+on:
+  workflow_call:
+    inputs:
+      job_type:
+        description: Which Docker CI task to run (test or lint)
+        required: true
+        type: string
+    secrets:
+      codecov_token:
+        description: Codecov token for test uploads
+        required: false
+
+jobs:
+  docker_ci:
+    runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.codecov_token }}
+      COMPOSE_PROJECT_NAME: mame-zefu
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build web image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.dev
+          load: true
+          tags: mame-zefu-web:latest
+          cache-from: type=gha,scope=mame-zefu-web
+          cache-to: type=gha,mode=max,scope=mame-zefu-web
+
+      - name: Start database
+        if: inputs.job_type == 'test'
+        run: docker compose up -d --wait postgres
+
+      - name: Compile assets
+        if: inputs.job_type == 'test'
+        run: docker compose run --rm -T -e SECRET_KEY_BASE=DUMMY web bin/rails assets:precompile
+
+      - name: Prepare test database
+        if: inputs.job_type == 'test'
+        run: docker compose run --rm -T -e RAILS_ENV=test web bin/rails db:prepare
+
+      - name: Run tests
+        if: inputs.job_type == 'test'
+        run: docker compose run --rm -T -e CI=true -e GITHUB_ACTIONS=true web bundle exec rspec --format documentation
+
+      - name: Rubocop
+        if: inputs.job_type == 'lint'
+        run: docker compose run --rm -T web bundle exec rubocop --parallel --format github
+
+      - name: ERB Lint
+        if: inputs.job_type == 'lint'
+        run: docker compose run --rm -T web bundle exec erb_lint --lint-all
+      - name: Tear down Docker services
+        if: always()
+        run: docker compose down --remove-orphans --volumes
+
+      - name: Upload to Codecov
+        if: inputs.job_type == 'test' && env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: coverage/coverage.xml

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -6,46 +6,13 @@ on:
     branches: [ "main" ]
 jobs:
   test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:15-alpine
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_DB: mame_zefu_test
-          POSTGRES_USER: mame_zefu
-          POSTGRES_PASSWORD: password
-    env:
-      RAILS_ENV: test
-      DATABASE_URL: "postgres://mame_zefu:password@localhost:5432/mame_zefu_test"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: Set up database schema
-        run: bin/rails db:schema:load
-      - name: Compile assets
-        run: SECRET_KEY_BASE=DUMMY bin/rails assets:precompile
-      - name: Run tests
-        run: bundle exec rspec --format documentation
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: ./.github/workflows/rails-docker-ci.yml
+    with:
+      job_type: test
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: Rubocop
-        run: bundle exec rubocop --parallel --format github
-      - name: ERB Lint
-        run: bundle exec erb_lint --lint-all
+    uses: ./.github/workflows/rails-docker-ci.yml
+    with:
+      job_type: lint

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,8 +30,7 @@ RUN python3 -m venv /opt/venv && \
 
 ENV PATH="/opt/venv/bin:$PATH"
 
-ENV RAILS_ENV="development" \
-    BUNDLE_PATH="/usr/local/bundle"
+ENV BUNDLE_PATH="/usr/local/bundle"
 
 COPY Gemfile Gemfile.lock ./
 RUN bundle install

--- a/bin/docker/dev
+++ b/bin/docker/dev
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+exec docker compose up --build web postgres "$@"

--- a/bin/docker/run
+++ b/bin/docker/run
@@ -1,0 +1,123 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+POSTGRES_STARTED_BY_SCRIPT=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bin/docker/run <rubocop|rspec|erb_lint|prettier|all> [args...]
+
+Examples:
+  bin/docker/run rubocop
+  bin/docker/run rspec spec/models/recipes_spec.rb
+  bin/docker/run erb_lint
+  bin/docker/run prettier
+  bin/docker/run all
+USAGE
+}
+
+web_is_running() {
+  docker compose exec -T web true >/dev/null 2>&1
+}
+
+compose_run_web() {
+  docker compose run --rm web "$@"
+}
+
+compose_exec_web() {
+  docker compose exec web "$@"
+}
+
+compose_web() {
+  if web_is_running; then
+    compose_exec_web "$@"
+    return
+  fi
+
+  compose_run_web "$@"
+}
+
+cleanup_postgres_if_needed() {
+  if [ "$POSTGRES_STARTED_BY_SCRIPT" -eq 1 ]; then
+    docker compose stop postgres >/dev/null
+  fi
+}
+
+ensure_postgres() {
+  if docker compose ps --status running -q postgres >/dev/null 2>&1 && \
+    [ -n "$(docker compose ps --status running -q postgres 2>/dev/null)" ]; then
+    return
+  fi
+
+  docker compose up -d postgres >/dev/null
+  POSTGRES_STARTED_BY_SCRIPT=1
+  trap cleanup_postgres_if_needed EXIT INT TERM
+}
+
+run_rubocop() {
+  compose_web bundle exec rubocop --parallel "$@"
+}
+
+run_rspec() {
+  ensure_postgres
+  if [ "$#" -eq 0 ]; then
+    compose_web env RAILS_ENV=test bundle exec rspec
+  else
+    compose_web env RAILS_ENV=test bundle exec rspec "$@"
+  fi
+}
+
+run_erb_lint() {
+  if [ "$#" -eq 0 ]; then
+    compose_web bundle exec erb_lint --lint-all
+  else
+    compose_web bundle exec erb_lint "$@"
+  fi
+}
+
+run_prettier() {
+  if [ "$#" -eq 0 ]; then
+    docker run --rm -v "$PWD:/work" -w /work node:22-alpine npx --yes prettier --check .
+  else
+    docker run --rm -v "$PWD:/work" -w /work node:22-alpine npx --yes prettier "$@"
+  fi
+}
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+target="$1"
+shift
+
+case "$target" in
+  rubocop)
+    run_rubocop "$@"
+    ;;
+  rspec)
+    run_rspec "$@"
+    ;;
+  erb_lint)
+    run_erb_lint "$@"
+    ;;
+  prettier)
+    run_prettier "$@"
+    ;;
+  all)
+    run_rubocop
+    run_erb_lint
+    run_prettier
+    run_rspec
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "Unknown target: $target"
+    usage
+    exit 1
+    ;;
+esac

--- a/bin/docker/shell
+++ b/bin/docker/shell
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+if docker compose exec -T web true >/dev/null 2>&1; then
+  exec docker compose exec web bash
+fi
+
+echo "web container is not running. Start it first with: bin/docker/dev"
+exit 1

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,6 @@
 services:
   web:
+    image: mame-zefu-web:latest
     build:
       context: .
       dockerfile: Dockerfile.dev
@@ -22,6 +23,12 @@ services:
       - POSTGRES_DB=mame_zefu_development
       - POSTGRES_USER=mame_zefu
       - POSTGRES_PASSWORD=password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mame_zefu -d mame_zefu_development"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
 volumes:
   cache:
   pgdata:

--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - DATABASE_URL=postgres://mame_zefu:password@postgres:5432/mame_zefu_development
+      - DB_HOST=postgres
   postgres:
     image: postgres:15-alpine
     volumes:

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: localhost
+  host: <%= ENV.fetch("DB_HOST", "localhost") %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
@@ -32,10 +32,10 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user running Rails.
-  
+
 
   # The password associated with the postgres role (username).
-  
+
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -84,5 +84,3 @@ test:
 #
 production:
   <<: *default
-  
-  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Please link to the issue/card here: -->

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Fixes some issues with docker compose development and adds utility scripts for running the server and tests. Also switches CI to run tests and lint inside docker.

### Start / Stop

```bash
bin/docker/dev
docker compose down # or Ctrl+C
```

### Shell

```bash
bin/docker/shell
```

### Run One Check

```bash
bin/docker/run rubocop
bin/docker/run rspec
bin/docker/run rspec spec/models/recipes_spec.rb
bin/docker/run erb_lint
bin/docker/run prettier
```

### Run Everything

```bash
bin/docker/run all
```

### Quick Notes

- `bin/docker/shell` requires the `web` container to already be running.
- `bin/docker/run` uses `docker compose exec` when `web` is running, and falls back to one-off containers when it is not.
- `bin/docker/run rspec` starts `postgres` if needed and stops it afterward only when it started it.